### PR TITLE
edit files to keep login state when site is reloaded

### DIFF
--- a/web/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/web/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,7 +19,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
+            return redirect()->route('user');
         }
 
         return $next($request);

--- a/web/app/Providers/RouteServiceProvider.php
+++ b/web/app/Providers/RouteServiceProvider.php
@@ -42,11 +42,12 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map()
     {
+        $this->mapInnerApiRoutes();
+
         $this->mapApiRoutes();
 
         $this->mapWebRoutes();
 
-        $this->mapInnerApiRoutes();
     }
 
     /**
@@ -88,6 +89,6 @@ class RouteServiceProvider extends ServiceProvider
         Route::prefix('api/v1')
              ->middleware('web')
              ->namespace($this->namespace)
-             ->group(base_path('routes/api.php'));
+             ->group(base_path('routes/innerApi.php'));
     }
 }

--- a/web/resources/ts/app.ts
+++ b/web/resources/ts/app.ts
@@ -3,10 +3,14 @@ import Vue from 'vue'
 import router from './router'
 import store from './store'
 import App from './App.vue'
-new Vue({
-  el: '#app',
-  router,
-  store,
-  components: { App },
-  template: '<App />'
-})
+const createApp = async () => {
+  await store.dispatch('auth/currentUser')
+  new Vue({
+    el: '#app',
+    router,
+    store,
+    components: { App },
+    template: '<App />'
+  })
+}
+createApp()

--- a/web/resources/ts/store/auth.ts
+++ b/web/resources/ts/store/auth.ts
@@ -26,6 +26,11 @@ const actions = {
   async logout (context: any) {
     const response = await axios.post('/api/v1/logout')
     context.commit('setUser', null)
+  },
+  async currentUser (context: any) {
+    const response = await axios.get('/api/v1/user')
+    const user: User = response.data || null
+    context.commit('setUser', user)
   }
 }
 

--- a/web/routes/innerApi.php
+++ b/web/routes/innerApi.php
@@ -12,7 +12,9 @@ use Illuminate\Http\Request;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
-
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::post('/register', 'Auth\RegisterController@register')->name('register');
+Route::post('/login', 'Auth\LoginController@login')->name('login');
+Route::post('/logout', 'Auth\LoginController@logout')->name('logout');
+Route::get('/user', function () {
+    return Auth::user();
+})->name('user');

--- a/web/tests/Feature/LoginApiTest.php
+++ b/web/tests/Feature/LoginApiTest.php
@@ -32,7 +32,7 @@ class LoginApiTest extends TestCase
             'email' => $this->user->email,
             'password' => 'password',
         ];
-        $response = $this->json('POST', route('login'), $data);
+        $response = $this->postJson(route('login'), $data);
         $response
             ->assertStatus(200)
             ->assertJson(['name' => $this->user->name]);

--- a/web/tests/Feature/LogoutApiTest.php
+++ b/web/tests/Feature/LogoutApiTest.php
@@ -28,8 +28,7 @@ class LogoutApiTest extends TestCase
      */
     public function test()
     {
-        $response = $this->actingAs($this->user)
-                        ->json('POST', route('logout'));
+        $response = $this->actingAs($this->user)->postJson(route('logout'));
         $response->assertStatus(200);
         $this->assertGuest();
     }

--- a/web/tests/Feature/RegisterApiTest.php
+++ b/web/tests/Feature/RegisterApiTest.php
@@ -24,7 +24,7 @@ class RegisterApiTest extends TestCase
              'password' => 'p@ssw0rd',
              'password_confirmation' => 'p@ssw0rd',
          ];
-         $response = $this->json('POST', route('register'), $data);
+         $response = $this->postJson(route('register'), $data);
          $user = User::first();
          $this->assertEquals($data['name'], $user->name);
          $response

--- a/web/tests/Feature/UserApiTest.php
+++ b/web/tests/Feature/UserApiTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UserApiTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * Create a test user.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * Return a logged in user.
+     *
+     * @test
+     */
+    public function testReturnLoggedInUser()
+    {
+        $response = $this->actingAs($this->user)->getJson(route('user'));
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+               'name' => $this->user->name,
+            ]);
+    }
+
+    /**
+     * Return null if nobody logged in.
+     *
+     * @test
+     */
+    public function testReturnNull()
+    {
+        $response = $this->json('GET', route('user'));
+        $response->assertStatus(200);
+        $this->assertEquals('', $response->content());
+    }
+}


### PR DESCRIPTION
- Create [`web/tests/Feature/UserApiTest.php`](https://github.com/toshikisugiyama/inventory-manager/blob/ef167684bf6a2a45a1f1708b27e02deb7402a2b7/web/tests/Feature/UserApiTest.php).
- Divide `web/routes/innerApi.php` and `web/routes/api.php`, and edit [`web/routes/innerApi.php`](https://github.com/toshikisugiyama/inventory-manager/blob/ef167684bf6a2a45a1f1708b27e02deb7402a2b7/web/routes/innerApi.php#L18-L20) in this application.
- `$this->mapInnerApiRoutes();` should be written before `$this->mapApiRoutes();` in [`web/app/Providers/RouteServiceProvider.php`](https://github.com/toshikisugiyama/inventory-manager/blob/ef167684bf6a2a45a1f1708b27e02deb7402a2b7/web/app/Providers/RouteServiceProvider.php#L43-L51).
- Edit [`web/resources/ts/app.ts`](https://github.com/toshikisugiyama/inventory-manager/blob/ef167684bf6a2a45a1f1708b27e02deb7402a2b7/web/resources/ts/app.ts#L6-L16) and [`web/resources/ts/store/auth.ts`](https://github.com/toshikisugiyama/inventory-manager/blob/ef167684bf6a2a45a1f1708b27e02deb7402a2b7/web/resources/ts/store/auth.ts#L30-L34) to check the current user when site is reloaded.